### PR TITLE
fix externals for go1.7.

### DIFF
--- a/interp/external.go
+++ b/interp/external.go
@@ -15,6 +15,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -108,6 +109,7 @@ func init() {
 		"runtime.Gosched":                  ext۰runtime۰Gosched,
 		"runtime.init":                     ext۰runtime۰init,
 		"runtime.NumCPU":                   ext۰runtime۰NumCPU,
+		"runtime.NumGoroutine":             ext۰runtime۰NumGoroutine,
 		"runtime.ReadMemStats":             ext۰runtime۰ReadMemStats,
 		"runtime.SetFinalizer":             ext۰runtime۰SetFinalizer,
 		"(*runtime.Func).Entry":            ext۰runtime۰Func۰Entry,
@@ -120,8 +122,9 @@ func init() {
 		"sync.runtime_Semacquire":          ext۰sync۰runtime_Semacquire,
 		"sync.runtime_Semrelease":          ext۰sync۰runtime_Semrelease,
 		"sync.runtime_Syncsemcheck":        ext۰sync۰runtime_Syncsemcheck,
-		"sync.runtime_canSpin":             sync۰runtime۰canSpin, // Elliott
-		"sync.runtime_doSpin":              sync۰runtime۰doSpin,  // Elliott
+		"sync.runtime_canSpin":             sync۰runtime۰canSpin,         // Elliott
+		"sync.runtime_doSpin":              sync۰runtime۰doSpin,          // Elliott
+		"sync.runtime_notifyListCheck":     sync۰runtime۰notifyListCheck, // Elliott
 		"sync.runtime_registerPoolCleanup": ext۰sync۰runtime_registerPoolCleanup,
 		"sync/atomic.AddInt32":             ext۰atomic۰AddInt32,
 		"sync/atomic.AddUint32":            ext۰atomic۰AddUint32,
@@ -173,6 +176,16 @@ func sync۰runtime۰canSpin(fr *frame, args []Ivalue) Ivalue { //i int) bool { /
 }
 func sync۰runtime۰doSpin(fr *frame, args []Ivalue) Ivalue { //) { // Elliott
 	runtime.Gosched()
+	return nil
+}
+
+// NumGoroutine returns the number of goroutines that currently exist.
+func ext۰runtime۰NumGoroutine(fr *frame, args []Ivalue) Ivalue { // Elliott
+	return int(atomic.LoadInt32(&fr.i.goroutines))
+}
+
+// Ensure that sync and runtime agree on size of notifyList.
+func sync۰runtime۰notifyListCheck(fr *frame, args []Ivalue) Ivalue { // Elliott
 	return nil
 }
 

--- a/ssainterp.go
+++ b/ssainterp.go
@@ -7,10 +7,9 @@ package ssainterp
 
 import (
 	"fmt"
+	"github.com/go-interpreter/ssainterp/interp"
 	"go/build"
 	"io"
-
-	"github.com/go-interpreter/ssainterp/interp"
 	//"./interp"
 
 	"go/types"


### PR DESCRIPTION
@elliott5 please have a look when you can.

This adds sync.runtime_notifyListCheck and runtime.NumGoroutine stubs. 

I tried calling the native runtime.NumGoroutine() in the runtime.NumGoroutine() thunk, but the goprint.go test apparently expects only one goroutine ever. Yep, crazy but true. Likely vestigial from earlier go version. Not sure how to best handle this. Perhaps the goprint.go test should just be skipped. By the way, is it legit to call the native runtime.NumGoroutine() directly like that? (see commented out line https://github.com/glycerine/ssainterp/commit/ab205b607431f5d3de898d6f31900dd5e34f91c3#diff-0cb90af343598265d6db5f9e8e4db65cR183).

At any rate, on my go1.7 osx, all the tests now pass.

Things to review/check before merging:

a) Wasn't sure if I was adding the //Elliott annotations at the rights points.
b) Wasn't sure if I should or could call the actual runtime.NumGoroutines() in the thunk.
c) Wasn't sure if the sync.runtime_notifyListCheck() thunk could or should try to do the same check that the native routine does. Is some critical consistency check being skipped now?

Fixes #3 
